### PR TITLE
Specify version in pygita

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ oauth2client
 pygments
 psycopg2-binary
 pySmartDL
-pygita
+pygita==1.0.0
 pybase64>=0.4.0
 pyfiglet
 pylast


### PR DESCRIPTION
`pygita v2.0.0` has been released today and it is not compatible with the code of `pygita v1.0.0`.
So to avoid the errors specifying version is must.